### PR TITLE
Fixed link opening

### DIFF
--- a/MarkdownViewer/Classes/RequestHandler.cs
+++ b/MarkdownViewer/Classes/RequestHandler.cs
@@ -14,6 +14,11 @@ namespace MarkdownViewer
                 Program.ChangeFile(uri.LocalPath);
                 return true;
             }
+            if (!uri.IsFile)
+            {
+                System.Diagnostics.Process.Start(request.Url);
+                return true;
+            }
 
             return false;
         }


### PR DESCRIPTION
When clicking on a link in a Preview mode, the link opens in a default browser (before it opened in the application, but there was no way to get back to the application).